### PR TITLE
Implement loading of scriptable object import definitions

### DIFF
--- a/Assets/Scripts/NotionImporter/Functions/SubFunctions/ScriptableObjects/MappingFunctions/ArrayMapping.cs
+++ b/Assets/Scripts/NotionImporter/Functions/SubFunctions/ScriptableObjects/MappingFunctions/ArrayMapping.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using UnityEditor;
 using UnityEngine;
@@ -40,28 +41,39 @@ namespace NotionImporter.Functions.SubFunction.ScriptableObjects {
 				(GUIStyle)"AM HeaderStyle");
 		}
 
-		public override void DrawKeyRow() {
-			var props = m_settings.CurrentProperty.Select(prop => prop.name).ToArray();
+                public override void DrawKeyRow() {
+                        var props = m_settings.CurrentProperty.Select(prop => prop.name).ToArray();
 
-			using (new EditorGUILayout.HorizontalScope()) {
-				m_useKeyProperty = EditorGUILayout.ToggleLeft($"キー列でグループ化", m_useKeyProperty);
+                        // 保存済み設定があればUI状態へ反映
+                        if (!string.IsNullOrEmpty(m_settings.KeyId)) {
+                                var idIndex = Array.FindIndex(m_settings.CurrentProperty, prop => prop.id == m_settings.KeyId);
 
-				using (new EditorGUI.DisabledScope(!m_useKeyProperty)) {
-					m_propertyIndex = EditorGUILayout.Popup(m_propertyIndex, props);
-				}
-			}
+                                if (idIndex >= 0) {
+                                        m_useKeyProperty = true;
+                                        m_propertyIndex = idIndex;
+                                }
+                        }
 
-			if (m_useKeyProperty) {
-				m_settings.KeyId = m_settings.CurrentProperty.FirstOrDefault(prop => prop.name == props[m_propertyIndex])?.id;
-			} else {
-				m_settings.KeyId = null;
-			}
+                        using (new EditorGUILayout.HorizontalScope()) {
+                                m_useKeyProperty = EditorGUILayout.ToggleLeft($"キー列でグループ化", m_useKeyProperty);
 
-			m_settings.UseKeyFiltering = EditorGUILayout.ToggleLeft("出力時にフィルタリングを行う", m_settings.UseKeyFiltering);
+                                using (new EditorGUI.DisabledScope(!m_useKeyProperty)) {
+                                        m_propertyIndex = EditorGUILayout.Popup(m_propertyIndex, props);
+                                }
+                        }
 
-			GUILayout.Box("", GUILayout.ExpandWidth(true), GUILayout.Height(1));
-			EditorGUILayout.Space();
-		}
+                        if (m_useKeyProperty) {
+                                m_settings.KeyId = m_settings.CurrentProperty
+                                        .ElementAtOrDefault(m_propertyIndex)?.id;
+                        } else {
+                                m_settings.KeyId = null;
+                        }
+
+                        m_settings.UseKeyFiltering = EditorGUILayout.ToggleLeft("出力時にフィルタリングを行う", m_settings.UseKeyFiltering);
+
+                        GUILayout.Box("", GUILayout.ExpandWidth(true), GUILayout.Height(1));
+                        EditorGUILayout.Space();
+                }
 
 		public override void DrawMappingRow(MappingFunction func, MappingItem itm) {
 			//ノーションのデータベースに変数にマッチするフィールドが存在するか？

--- a/Assets/Scripts/NotionImporter/Functions/SubFunctions/ScriptableObjects/TypePaneFunction.cs
+++ b/Assets/Scripts/NotionImporter/Functions/SubFunctions/ScriptableObjects/TypePaneFunction.cs
@@ -16,11 +16,22 @@ namespace NotionImporter.Functions.SubFunction.ScriptableObjects {
 		/// <summary> マッピング対象の型情報配列 </summary>
 		private TypeItem[] m_mappingTargetTypes;
 
-		public TypeItem[] MappingTargetTypes {
-			get {
-				return m_mappingTargetTypes;
-			}
-		}
+                public TypeItem[] MappingTargetTypes {
+                        get {
+                                return m_mappingTargetTypes;
+                        }
+                }
+
+                /// <summary> 読込時に型キャッシュを確実に初期化する </summary>
+                public void EnsureTypeList(NotionImporterSettings settings) {
+                        m_settings = settings; // 最新設定を保持
+
+                        if (m_mappingTargetTypes == null || m_settings.CurrentObject != m_currentDatabase) {
+                                // DB変更時などに型一覧を再生成
+                                m_mappingTargetTypes = GetTypeItems();
+                                m_currentDatabase = m_settings.CurrentObject;
+                        }
+                }
 
 		public TypeItem SelectedMappingTargetTypes {
 			get {


### PR DESCRIPTION
## Summary
- hydrate the scriptable object import setup from saved JSON definitions
- keep the type cache and key filter UI in sync when loading settings
- restore collection targets and mapping selections for array/list mappings

## Testing
- not run (Unity project)

------
https://chatgpt.com/codex/tasks/task_e_68d1ca1db9b08323a300896a98fab16c