### PR TITLE
Fix async property fetch when outputting scriptable objects

### DIFF
--- a/Assets/Scripts/NotionImporter/Functions/OutputFunctions/OutputScriptableObject.cs
+++ b/Assets/Scripts/NotionImporter/Functions/OutputFunctions/OutputScriptableObject.cs
@@ -154,11 +154,11 @@ namespace NotionImporter.Functions.Output {
 						foreach (var dat in def.mappingData) {
 							var targetPropId = dat.targetPropertyId;
 
-							foreach (var prop in props) {
-								if(prop.Value.id == targetPropId) {
-									var propValue = NotionUtils.GetStringProperty(m_settings, prop.Value);
+                                                        foreach (var prop in props) {
+                                                                if(prop.Value.id == targetPropId) {
+                                                                        var propValue = await NotionUtils.GetStringProperty(m_settings, prop.Value); // 非同期結果を待って文字列を取得
 
-									SetObjectField(so, dat.targetFieldName, propValue);
+                                                                        SetObjectField(so, dat.targetFieldName, propValue);
 
 									break;
 								}


### PR DESCRIPTION
## Summary
- await the Notion property fetch when mapping ScriptableObject fields so that the real string value is used
- document the await to highlight why the asynchronous call is required

## Testing
- not run (Unity project)

------
https://chatgpt.com/codex/tasks/task_e_68d28f3bc5d88323a32de9a40715a6c0