### PR TITLE
Organize NotionImporter JSON output directories

### DIFF
--- a/Assets/Scripts/NotionImporter/Editor/Functions/SubFunctions/CreateScriptableObjectDefinition.cs
+++ b/Assets/Scripts/NotionImporter/Editor/Functions/SubFunctions/CreateScriptableObjectDefinition.cs
@@ -57,14 +57,13 @@ namespace NotionImporter.Functions.SubFunction {
 				return;
 			}
 
-			if(!Directory.Exists(NotionImporterParameters.DefinitionFilePath + $"\\{nameof(ScriptableObjectImportDefinition)}")) {
-				Directory.CreateDirectory(NotionImporterParameters.DefinitionFilePath +
-					$"\\{nameof(ScriptableObjectImportDefinition)}");
+			var definitionCategoryPath = Path.Combine(NotionImporterParameters.DefinitionFilePath, nameof(ScriptableObjectImportDefinition)); // 型毎の定義を格納するフォルダ
+
+			if(!Directory.Exists(definitionCategoryPath)) {
+				Directory.CreateDirectory(definitionCategoryPath); // カテゴリフォルダを事前生成
 			}
 
-			var filePath = NotionImporterParameters.DefinitionFilePath + // 型名のフォルダに定義ファイルを保存
-				$"\\{nameof(ScriptableObjectImportDefinition)}" +
-				$"\\{m_settings.DefinitionName}.json";
+			var filePath = Path.Combine(definitionCategoryPath, $"{m_settings.DefinitionName}.json"); // 型名のフォルダに定義ファイルを保存
 
 			var soSetting = new ScriptableObjectImportDefinition {
 				outputPath = m_settings.OutputPath,

--- a/Assets/Scripts/NotionImporter/Editor/MainImportWindow.cs
+++ b/Assets/Scripts/NotionImporter/Editor/MainImportWindow.cs
@@ -41,7 +41,7 @@ namespace NotionImporter {
 			var icon = AssetDatabase.LoadAssetAtPath<Texture2D>(NotionImporterParameters.IconPath);
 
 			if(!Directory.Exists(NotionImporterParameters.DefinitionFilePath)) { // 定義フォルダの存在確認。無ければ作成してプロジェクトビューを更新
-				AssetDatabase.CreateFolder(NotionImporterParameters.BasePath, NotionImporterParameters.DefinitionDirectoryName);
+				Directory.CreateDirectory(NotionImporterParameters.DefinitionFilePath); // ルートから生成して配置場所を固定
 				AssetDatabase.Refresh();
 			}
 

--- a/Assets/Scripts/NotionImporter/Editor/NotionImporterParameters.cs
+++ b/Assets/Scripts/NotionImporter/Editor/NotionImporterParameters.cs
@@ -9,6 +9,10 @@ namespace NotionImporter {
 
 		public const string PROGRAM_ID = "NotionImporter"; // プログラム識別子
 
+		private const string CONFIG_ROOT_DIRECTORY = "Assets/NotionImporter/Editor"; // 設定と定義のルート
+		private const string SETTINGS_DIRECTORY_NAME = "Settings";                   // 設定JSONをまとめるフォルダ名
+		private const string DEFINITION_ROOT_DIRECTORY_NAME = "Definitions";         // 定義JSONの親フォルダ名
+
 		/// <summary>Notionインポータウィンドウのタイトル文字を取得します。</summary>
 		public static string WindowTitle => PROGRAM_ID; // ウィンドウタイトルとしてプログラムIDを返す
 
@@ -27,13 +31,13 @@ namespace NotionImporter {
 
 		/// <summary>インポート設定ファイルのパスを取得します。</summary>
 		public static string SettingFilePath
-			=> BasePath + "\\ImporterSettings.json"; // 基準パスに設定ファイル名を結合
+			=> Path.Combine(CONFIG_ROOT_DIRECTORY, SETTINGS_DIRECTORY_NAME, "ImporterSettings.json"); // 設定は専用フォルダへ配置
 
 		public static readonly string DefinitionDirectoryName = "DatabaseDefinitions"; // データベース定義を格納するディレクトリ名
 
 		/// <summary>データベース定義フォルダのパスを取得します。</summary>
 		public static string DefinitionFilePath
-			=> BasePath + $"\\{DefinitionDirectoryName}"; // 基準パスに定義ディレクトリ名を結合
+			=> Path.Combine(CONFIG_ROOT_DIRECTORY, DEFINITION_ROOT_DIRECTORY_NAME, DefinitionDirectoryName); // 定義用のジャンルフォルダに出力
 
 	}
 

--- a/Assets/Scripts/NotionImporter/Editor/NotionImporterSettings.cs
+++ b/Assets/Scripts/NotionImporter/Editor/NotionImporterSettings.cs
@@ -203,6 +203,12 @@ namespace NotionImporter {
 			try {
 				var json = JsonUtility.ToJson(setting); // インポータ設定を書き出し
 
+				var settingDirectory = Path.GetDirectoryName(NotionImporterParameters.SettingFilePath); // 設定保存用ディレクトリを取得
+
+				if(!string.IsNullOrEmpty(settingDirectory) && !Directory.Exists(settingDirectory)) {
+					Directory.CreateDirectory(settingDirectory); // 事前にフォルダを生成して出力先を保証
+				}
+
 				File.WriteAllText(NotionImporterParameters.SettingFilePath, json); // 設定ファイルへ書き出し
 
 				AssetDatabase.Refresh(); // Unity エディタにアセット変更を通知


### PR DESCRIPTION
## Summary
- store NotionImporter settings and definition JSON files under Assets/NotionImporter/Editor with genre-specific folders
- ensure the required directories are created before writing configuration files to disk

## Testing
- not run (Unity project)


------
https://chatgpt.com/codex/tasks/task_e_68d921c4b9548323a58263d3a6c996cc