### PR TITLE
Warn when Notion API key is missing

### DIFF
--- a/Assets/Scripts/NotionImporter/Editor/MainImportWindow.cs
+++ b/Assets/Scripts/NotionImporter/Editor/MainImportWindow.cs
@@ -144,18 +144,22 @@ namespace NotionImporter {
 			DrawBlockWithErrorHandling(
 				"ヘッダー",
 				() => {
-					using (new GUILayout.HorizontalScope()) {
-						m_connector.ImporterSettings.apiKey = EditorGUILayout.TextField("Notion APIキー", m_connector.ImporterSettings.apiKey); // APIキー入力欄（即時反映）
+                                        using (new GUILayout.HorizontalScope()) {
+                                                m_connector.ImporterSettings.apiKey = EditorGUILayout.TextField("Notion APIキー", m_connector.ImporterSettings.apiKey); // APIキー入力欄（即時反映）
 
-						if(GUILayout.Button("更新", GUILayout.Width(50))) {
-							ExecuteWithErrorHandling("Notionへの再接続", () => m_connector.ForceConnect()); // 明示的に再接続を要求（認証情報が変わった際に使用）
-						}
-					}
-				},
-				message => {
-					using (new GUILayout.HorizontalScope()) {
-						EditorGUILayout.LabelField(message, EditorStyles.boldLabel); // 描画不能時は領域内にエラーを表示
-					}
+                                                if(GUILayout.Button("更新", GUILayout.Width(50))) {
+                                                        ExecuteWithErrorHandling("Notionへの再接続", () => m_connector.ForceConnect()); // 明示的に再接続を要求（認証情報が変わった際に使用）
+                                                }
+                                        }
+
+                                        if(string.IsNullOrWhiteSpace(m_connector.ImporterSettings.apiKey)) { // APIキー未設定時の警告表示
+                                                EditorGUILayout.HelpBox("Notion APIキーが未入力です。設定してください。", MessageType.Warning);
+                                        }
+                                },
+                                message => {
+                                        using (new GUILayout.HorizontalScope()) {
+                                                EditorGUILayout.LabelField(message, EditorStyles.boldLabel); // 描画不能時は領域内にエラーを表示
+                                        }
 				});
 		}
 

--- a/Assets/Scripts/NotionImporter/Editor/Utils/NotionConnector.cs
+++ b/Assets/Scripts/NotionImporter/Editor/Utils/NotionConnector.cs
@@ -48,7 +48,13 @@ namespace NotionImporter {
 					return;
 				}
 
-				m_mainWindow.CurrentStatusString = "接続開始"; // ステータスを接続開始に変更する
+                                if(string.IsNullOrWhiteSpace(ImporterSettings.apiKey)) { // APIキー未入力時は接続を打ち切る
+                                        IsConnected = false;
+                                        m_mainWindow.CurrentStatusString = "Notion APIキーが未設定です"; // ステータスに未設定を表示
+                                        return;
+                                }
+
+                                m_mainWindow.CurrentStatusString = "接続開始"; // ステータスを接続開始に変更する
 
 				ImporterSettings.RefreshDatabaseInfo(); // データベース情報の更新を行う
 


### PR DESCRIPTION
## Summary
- prevent connection attempts when the Notion API key is empty and surface a status message instead
- surface a warning help box in the header to clearly prompt for entering the API key

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9eb75fe8c8323ad4356c05b89bda4