### PR TITLE
Fix Notion tree refresh on update

### DIFF
--- a/Assets/Scripts/NotionImporter/Editor/Functions/CreateImportDefinition.cs
+++ b/Assets/Scripts/NotionImporter/Editor/Functions/CreateImportDefinition.cs
@@ -40,6 +40,8 @@ namespace NotionImporter.Functions {
 		/// <summary>表示に使用するNotionツリーを取得します。</summary>
 		public NotionTree NotionTree => m_notionTree;
 
+		private NotionObject[] m_cachedNotionObjects; // 最新のNotionオブジェクト参照を保持
+
 		/// <summary>Notionインポータの機能を描画する</summary>
 		public void DrawFunction(MainImportWindow parent, NotionImporterSettings settings) {
 			m_parent = parent; // 親ウィンドウと設定情報を保持
@@ -76,9 +78,15 @@ namespace NotionImporter.Functions {
 			}
 		}
 
-                /// <summary>Notionのデータベース構造をツリー表示します。</summary>
-                private void DrawNotionTree() {
-                        using (new EditorGUILayout.VerticalScope(GUI.skin.textArea)) { // Notionオブジェクトを一覧表示する枠を描画
+		/// <summary>Notionのデータベース構造をツリー表示します。</summary>
+		private void DrawNotionTree() {
+			if(!ReferenceEquals(m_cachedNotionObjects, m_settings.objects)) {
+				m_cachedNotionObjects = m_settings.objects; // 新しい取得結果に更新
+				m_notionTree = null;
+				m_treeViewState = null; // ⭐ データ更新時はツリーを作り直して最新状態を表示
+			}
+
+			using (new EditorGUILayout.VerticalScope(GUI.skin.textArea)) { // Notionオブジェクトを一覧表示する枠を描画
                                 using (new EditorGUILayout.HorizontalScope("AC BoldHeader")) {
                                         GUILayout.Label("Notionオブジェクト", "ProfilerHeaderLabel");
                                 }

--- a/Assets/Scripts/NotionImporter/package.json
+++ b/Assets/Scripts/NotionImporter/package.json
@@ -2,7 +2,7 @@
     "name": "com.anest.notionimporter",
     "displayName": "Notion Importer",
     "author": { "name": "Mikan Yukkuri", "url": "https://github.com/YukkuriMikan" },
-    "version": "1.0.3",
+    "version": "1.0.4",
     "unity": "2021.3",
     "description": "Import Notion data into Unity.",
     "dependencies": {


### PR DESCRIPTION
## Summary
- reset the Notion object tree when a fresh database list is downloaded so the UI rebuilds
- bump the package version to 1.0.4 for the bugfix release

## Testing
- not run (Unity editor UI change)


------
https://chatgpt.com/codex/tasks/task_e_68de71b9bc9c8323a6f2f7372a280601