### PR TITLE
Use Equals for array element reuse in ScriptableObject output and bump package version

### DIFF
--- a/Assets/Scripts/NotionImporter/Editor/Functions/OutputFunctions/OutputScriptableObject.cs
+++ b/Assets/Scripts/NotionImporter/Editor/Functions/OutputFunctions/OutputScriptableObject.cs
@@ -185,7 +185,7 @@ namespace NotionImporter.Functions.Output {
 			}
 
 			soValues = SortCollectionIfNeeded(def, soValues); // 出力直前に並べ替えを適用
-			soValues = ReuseArrayElementsIfMatched(so, def, soValues); // == で一致する既存要素を再利用
+			soValues = ReuseArrayElementsIfMatched(so, def, soValues); // Equals一致する既存要素を再利用（struct対応）
 
 			var arrayType = def.targetFieldType.targetType; // キー列設定あり
 			var instance = Activator.CreateInstance(arrayType, soValues.Length);
@@ -202,7 +202,7 @@ namespace NotionImporter.Functions.Output {
 			Debug.Log($"NotionImporter: {assetName} Imported.");
 		}
 
-		private object[] ReuseArrayElementsIfMatched(ScriptableObject so, ScriptableObjectImportDefinition def, object[] soValues) { // 既存配列と==一致する要素を使い回す
+		private object[] ReuseArrayElementsIfMatched(ScriptableObject so, ScriptableObjectImportDefinition def, object[] soValues) { // 既存配列とEquals一致する要素を使い回す
 			if(so == null || def == null || soValues == null || soValues.Length == 0 || string.IsNullOrWhiteSpace(def.targetFieldName)) {
 				return soValues;
 			}
@@ -236,11 +236,8 @@ namespace NotionImporter.Functions.Output {
 			return soValues;
 		}
 
-		private static bool IsDoubleEqual(object left, object right) { // == 演算子定義がある型はそれを尊重する
-			dynamic dynamicLeft = left;
-			dynamic dynamicRight = right;
-
-			return dynamicLeft == dynamicRight;
+		private static bool IsDoubleEqual(object left, object right) { // structを含む要素比較はEqualsで統一
+			return Equals(left, right);
 		}
 
 		private object[] SortCollectionIfNeeded(ScriptableObjectImportDefinition def, object[] soValues) { // 並べ替え処理の入口

--- a/Assets/Scripts/NotionImporter/package.json
+++ b/Assets/Scripts/NotionImporter/package.json
@@ -2,7 +2,7 @@
     "name": "com.anest.notionimporter",
     "displayName": "Notion Importer",
     "author": { "name": "Mikan Yukkuri", "url": "https://github.com/YukkuriMikan" },
-    "version": "1.0.7",
+    "version": "1.0.8",
     "unity": "2021.3",
     "description": "Import Notion data into Unity.",
     "dependencies": {


### PR DESCRIPTION
### Motivation
- `OutputScriptableObject` の配列要素再利用判定で `==` を用いると `struct` 等で正しく比較できないため、`Equals` に統一して再利用ロジックの安全性を向上させました。

### Description
- `Assets/Scripts/NotionImporter/Editor/Functions/OutputFunctions/OutputScriptableObject.cs` の比較処理を動的 `==` から `Equals(left, right)` に変更し、関連コメントを更新しました、並びに `Assets/Scripts/NotionImporter/package.json` の `version` を `1.0.7` から `1.0.8` にインクリメントしました。

### Testing
- 実行した自動検査は `git diff --check` と `python -m json.tool Assets/Scripts/NotionImporter/package.json` による整合性チェックで、いずれも成功しました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba383fc17883239c8aa2a140c5de7f)