### PR TITLE
複数ソートキー対応: UI / 定義 / 出力を拡張

### DIFF
--- a/Assets/Scripts/NotionImporter/Editor/Functions/OutputFunctions/OutputScriptableObject.cs
+++ b/Assets/Scripts/NotionImporter/Editor/Functions/OutputFunctions/OutputScriptableObject.cs
@@ -13,6 +13,14 @@ namespace NotionImporter.Functions.Output {
 	/// <summary> スクリプタブルオブジェクトを出力 </summary>
 	public class OutputScriptableObject : IOutputFunction {
 
+		private class SortFieldRule {
+
+			public FieldInfo fieldInfo; // 比較に使うフィールド情報
+
+			public SortOrder sortOrder; // このキーでの並び順
+
+		}
+
 		public Type DefinitionType
 			=> typeof(ScriptableObjectImportDefinition);
 
@@ -245,7 +253,7 @@ namespace NotionImporter.Functions.Output {
 				return soValues; // nullや単要素はそのまま返す
 			}
 
-			if(string.IsNullOrEmpty(def.sortKey) || def.targetFieldType?.targetType == null) {
+			if(def.targetFieldType?.targetType == null) {
 				return soValues; // ソートが不要なケース
 			}
 
@@ -255,65 +263,118 @@ namespace NotionImporter.Functions.Output {
 				return soValues; // 要素型が特定できない場合はスキップ
 			}
 
-			var sortField = elementType.GetField(def.sortKey, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+			var sortRules = BuildSortRules(def, elementType);
 
-			if(sortField == null) {
-				Debug.LogWarning($"NotionImporter: ソートキー「{def.sortKey}」が型「{elementType.FullName}」に見つかりませんでした。");
-
+			if(sortRules.Length == 0) {
 				return soValues;
 			}
 
 			var sorted = soValues.ToArray();
 
-			Array.Sort(sorted, (left, right) => CompareSortValues(sortField.GetValue(left), sortField.GetValue(right), def.sortOrder));
+			Array.Sort(sorted, (left, right) => CompareSortByRules(left, right, sortRules));
 
 			return sorted;
 		}
 
-                private static Type GetCollectionElementType(Type collectionType) { // 定義されたコレクションから要素型を推定
-                        if(collectionType == null) {
-                                return null;
-                        }
+		private SortFieldRule[] BuildSortRules(ScriptableObjectImportDefinition def, Type elementType) { // 有効なソートキーのみ抽出
+			var rawConditions = GetEffectiveSortConditions(def);
+			var result = rawConditions
+				.Where(condition => !string.IsNullOrEmpty(condition?.sortKey))
+				.Select(condition => new {
+					condition.sortKey,
+					condition.sortOrder,
+					fieldInfo = elementType.GetField(condition.sortKey, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic),
+				})
+				.Where(item => {
+					if(item.fieldInfo != null) {
+						return true;
+					}
 
-                        if(collectionType.IsArray) {
-                                return collectionType.GetElementType();
-                        }
+					Debug.LogWarning($"NotionImporter: ソートキー「{item.sortKey}」が型「{elementType.FullName}」に見つかりませんでした。");
+					return false;
+				})
+				.Select(item => new SortFieldRule {
+					fieldInfo = item.fieldInfo,
+					sortOrder = item.sortOrder,
+				})
+				.ToArray();
 
-                        if(collectionType.IsGenericType && collectionType.GetGenericArguments().Length == 1) {
-                                return collectionType.GetGenericArguments()[0];
-                        }
+			return result;
+		}
 
-                        return null;
-                }
+		private static SortCondition[] GetEffectiveSortConditions(ScriptableObjectImportDefinition def) { // 新仕様優先、旧仕様へフォールバック
+			if(def.sortConditions != null && def.sortConditions.Length > 0) {
+				return def.sortConditions;
+			}
 
-                private static int CompareSortValues(object left, object right, SortOrder order) { // ソート順に応じて比較結果を調整
-                        var result = CompareRawValues(left, right);
+			if(!string.IsNullOrEmpty(def.sortKey)) {
+				return new[] {
+					new SortCondition {
+						sortKey = def.sortKey,
+						sortOrder = def.sortOrder,
+					}
+				};
+			}
 
-                        return order == SortOrder.Ascending ? result : -result; // 降順は符号反転
-                }
+			return Array.Empty<SortCondition>();
+		}
 
-                private static int CompareRawValues(object left, object right) { // nullや比較不能な値を安全に処理
-                        if(left == null && right == null) {
-                                return 0;
-                        }
+		private static int CompareSortByRules(object left, object right, SortFieldRule[] sortRules) { // 複数キーを順番に比較
+			foreach (var rule in sortRules) {
+				var compared = CompareSortValues(rule.fieldInfo.GetValue(left), rule.fieldInfo.GetValue(right), rule.sortOrder);
 
-                        if(left == null) {
-                                return -1;
-                        }
+				if(compared != 0) {
+					return compared;
+				}
+			}
 
-                        if(right == null) {
-                                return 1;
-                        }
+			return 0;
+		}
 
-                        if(left is IComparable leftComparable && right is IComparable rightComparable) {
-                                return leftComparable.CompareTo(rightComparable);
-                        }
+		private static Type GetCollectionElementType(Type collectionType) { // 定義されたコレクションから要素型を推定
+			if(collectionType == null) {
+				return null;
+			}
 
-                        var leftText = left?.ToString();
-                        var rightText = right?.ToString();
+			if(collectionType.IsArray) {
+				return collectionType.GetElementType();
+			}
 
-                        return string.Compare(leftText, rightText, StringComparison.Ordinal);
-                }
+			if(collectionType.IsGenericType && collectionType.GetGenericArguments().Length == 1) {
+				return collectionType.GetGenericArguments()[0];
+			}
+
+			return null;
+		}
+
+		private static int CompareSortValues(object left, object right, SortOrder order) { // ソート順に応じて比較結果を調整
+			var result = CompareRawValues(left, right);
+
+			return order == SortOrder.Ascending ? result : -result; // 降順は符号反転
+		}
+
+		private static int CompareRawValues(object left, object right) { // nullや比較不能な値を安全に処理
+			if(left == null && right == null) {
+				return 0;
+			}
+
+			if(left == null) {
+				return -1;
+			}
+
+			if(right == null) {
+				return 1;
+			}
+
+			if(left is IComparable leftComparable && right is IComparable rightComparable) {
+				return leftComparable.CompareTo(rightComparable);
+			}
+
+			var leftText = left?.ToString();
+			var rightText = right?.ToString();
+
+			return string.Compare(leftText, rightText, StringComparison.Ordinal);
+		}
 
                 private object SetObjectField(object targetObject, string fieldName, string value) {
                         var field = targetObject.GetType()

--- a/Assets/Scripts/NotionImporter/Editor/Functions/SubFunctions/CreateScriptableObjectDefinition.cs
+++ b/Assets/Scripts/NotionImporter/Editor/Functions/SubFunctions/CreateScriptableObjectDefinition.cs
@@ -73,12 +73,13 @@ namespace NotionImporter.Functions.SubFunction {
 				mappingMode = m_mappingFunction.MappingMode,
 				keyProperty = m_settings.KeyId,
 				useKeyFiltering = m_settings.UseKeyFiltering,
-                                targetFieldType = m_mappingFunction.CurrentMappingMethod.MethodTargetArrayType,
-                                targetFieldName = m_mappingFunction.CurrentMappingMethod.MethodTarget?.fieldName,
-                                mappingData = m_mappingFunction.CurrentMappingMethod.GetMappingData(),
-                                sortKey = m_settings.SortKey,
-                                sortOrder = m_settings.SortOrder,
-                        };
+				targetFieldType = m_mappingFunction.CurrentMappingMethod.MethodTargetArrayType,
+				targetFieldName = m_mappingFunction.CurrentMappingMethod.MethodTarget?.fieldName,
+				mappingData = m_mappingFunction.CurrentMappingMethod.GetMappingData(),
+				sortKey = m_settings.SortKey,
+				sortOrder = m_settings.SortOrder,
+				sortConditions = BuildDefinitionSortConditions(),
+			};
 
 			var jsonText = JsonUtility.ToJson(soSetting);
 
@@ -115,12 +116,14 @@ namespace NotionImporter.Functions.SubFunction {
 
 			m_settings.DefinitionName = definition.definitionName;
 			m_settings.OutputPath = definition.outputPath;
-                        m_settings.KeyId = definition.keyProperty;
-                        m_settings.UseKeyFiltering = definition.useKeyFiltering;
-                        m_settings.SortKey = definition.sortKey; // 並べ替え設定を復元
-                        m_settings.SortOrder = Enum.IsDefined(typeof(SortOrder), definition.sortOrder)
-                                ? definition.sortOrder
-                                : SortOrder.Ascending; // 互換性確保のため異常値は昇順扱い
+			m_settings.KeyId = definition.keyProperty;
+			m_settings.UseKeyFiltering = definition.useKeyFiltering;
+			m_settings.SortConditions = BuildSettingsSortConditions(definition);
+
+			var firstSortCondition = m_settings.SortConditions.FirstOrDefault(condition => !string.IsNullOrEmpty(condition.sortKey));
+
+			m_settings.SortKey = firstSortCondition?.sortKey;
+			m_settings.SortOrder = firstSortCondition?.sortOrder ?? SortOrder.Ascending;
 
 			m_typePaneFunction.EnsureTypeList(m_settings); // 型リストを確実に初期化
 
@@ -149,6 +152,58 @@ namespace NotionImporter.Functions.SubFunction {
 			}
 
 			ApplyMappingData(definition.mappingData);
+		}
+
+		/// <summary>定義ファイルへ保存するソート条件を構築します。</summary>
+		private SortCondition[] BuildDefinitionSortConditions() {
+			if(m_settings.SortConditions != null && m_settings.SortConditions.Length > 0) {
+				return m_settings.SortConditions
+					.Where(condition => condition != null)
+					.Select(condition => new SortCondition {
+						sortKey = condition.sortKey,
+						sortOrder = condition.sortOrder,
+					})
+					.ToArray();
+			}
+
+			if(!string.IsNullOrEmpty(m_settings.SortKey)) {
+				return new[] {
+					new SortCondition {
+						sortKey = m_settings.SortKey,
+						sortOrder = m_settings.SortOrder,
+					}
+				};
+			}
+
+			return Array.Empty<SortCondition>();
+		}
+
+		/// <summary>定義ファイルから読み込んだソート条件を設定へ復元します。</summary>
+		private SortCondition[] BuildSettingsSortConditions(ScriptableObjectImportDefinition definition) {
+			if(definition.sortConditions != null && definition.sortConditions.Length > 0) {
+				return definition.sortConditions
+					.Where(condition => condition != null)
+					.Select(condition => new SortCondition {
+						sortKey = condition.sortKey,
+						sortOrder = Enum.IsDefined(typeof(SortOrder), condition.sortOrder)
+							? condition.sortOrder
+							: SortOrder.Ascending,
+					})
+					.ToArray();
+			}
+
+			if(!string.IsNullOrEmpty(definition.sortKey)) {
+				return new[] {
+					new SortCondition {
+						sortKey = definition.sortKey,
+						sortOrder = Enum.IsDefined(typeof(SortOrder), definition.sortOrder)
+							? definition.sortOrder
+							: SortOrder.Ascending,
+					}
+				};
+			}
+
+			return Array.Empty<SortCondition>();
 		}
 
 		/// <summary>配列/リストマッピング設定を復元する</summary>

--- a/Assets/Scripts/NotionImporter/Editor/Functions/SubFunctions/ScriptableObjects/MappingFunctions/ArrayMapping.cs
+++ b/Assets/Scripts/NotionImporter/Editor/Functions/SubFunctions/ScriptableObjects/MappingFunctions/ArrayMapping.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using UnityEditor;
 using UnityEngine;
@@ -64,59 +65,118 @@ namespace NotionImporter.Functions.SubFunction.ScriptableObjects {
                                 m_settings.KeyId = null;
                         }
 
-                        m_settings.UseKeyFiltering = EditorGUILayout.ToggleLeft("出力時にフィルタリングを行う", m_settings.UseKeyFiltering);
+			m_settings.UseKeyFiltering = EditorGUILayout.ToggleLeft("出力時にフィルタリングを行う", m_settings.UseKeyFiltering);
 
-                        var mappingItems = MethodMappingItems ?? Array.Empty<MappingItem>(); // ソート候補となるフィールド群
-                        var sortKeyLabels = new string[mappingItems.Length + 1];
-                        var sortKeyValues = new string[mappingItems.Length + 1];
+			var mappingItems = MethodMappingItems ?? Array.Empty<MappingItem>(); // ソート候補となるフィールド群
+			var sortKeyLabels = new string[mappingItems.Length + 1];
+			var sortKeyValues = new string[mappingItems.Length + 1];
 
-                        sortKeyLabels[0] = "（ソートしない）";
-                        sortKeyValues[0] = string.Empty;
+			sortKeyLabels[0] = "（ソートしない）";
+			sortKeyValues[0] = string.Empty;
 
-                        for (var i = 0; i < mappingItems.Length; i++) {
-                                var item = mappingItems[i];
+			for (var i = 0; i < mappingItems.Length; i++) {
+				var item = mappingItems[i];
 
-                                sortKeyLabels[i + 1] = $"{item.fieldName}:{item.fieldInfo?.FieldType.Name}";
-                                sortKeyValues[i + 1] = item.fieldName;
-                        }
+				sortKeyLabels[i + 1] = $"{item.fieldName}:{item.fieldInfo?.FieldType.Name}";
+				sortKeyValues[i + 1] = item.fieldName;
+			}
 
-                        var currentSortKey = string.IsNullOrEmpty(m_settings.SortKey) ? string.Empty : m_settings.SortKey;
-                        var sortKeyIndex = Array.IndexOf(sortKeyValues, currentSortKey);
+			var sortConditions = BuildEditableSortConditions();
+			int removeAt = -1; // 描画中に削除が押された行番号を後で反映
 
-                        if(sortKeyIndex < 0) {
-                                sortKeyIndex = 0;
-                                m_settings.SortKey = null;
-                        }
+			for (var i = 0; i < sortConditions.Count; i++) {
+				var condition = sortConditions[i];
+				var currentSortKey = string.IsNullOrEmpty(condition.sortKey) ? string.Empty : condition.sortKey;
+				var sortKeyIndex = Array.IndexOf(sortKeyValues, currentSortKey);
 
-                        using (new EditorGUILayout.HorizontalScope()) {
-                                EditorGUILayout.LabelField("ソートキー", GUILayout.Width(80));
-                                sortKeyIndex = EditorGUILayout.Popup(sortKeyIndex, sortKeyLabels);
-                        }
+				if(sortKeyIndex < 0) {
+					sortKeyIndex = 0;
+					condition.sortKey = null;
+				}
 
-                        m_settings.SortKey = sortKeyIndex <= 0 ? null : sortKeyValues[sortKeyIndex]; // 選択したフィールド名を保存
+				using (new EditorGUILayout.HorizontalScope()) {
+					EditorGUILayout.LabelField($"第{i + 1}キー", GUILayout.Width(80));
+					sortKeyIndex = EditorGUILayout.Popup(sortKeyIndex, sortKeyLabels);
+					condition.sortKey = sortKeyIndex <= 0 ? null : sortKeyValues[sortKeyIndex];
 
-                        using (new EditorGUILayout.HorizontalScope()) {
-                                EditorGUILayout.LabelField("ソート順", GUILayout.Width(80));
+					using (new EditorGUI.DisabledScope(sortKeyIndex == 0)) {
+						var sortOrderLabels = new[] {
+							"昇順",
+							"降順",
+						};
 
-                                using (new EditorGUI.DisabledScope(sortKeyIndex == 0)) {
-                                        var sortOrderLabels = new[] {
-                                                "昇順",
-                                                "降順",
-                                        };
+						var orderIndex = EditorGUILayout.Popup((int)condition.sortOrder, sortOrderLabels, GUILayout.Width(70));
+						orderIndex = Mathf.Clamp(orderIndex, 0, sortOrderLabels.Length - 1);
+						condition.sortOrder = (SortOrder)orderIndex;
+					}
 
-                                        var orderIndex = EditorGUILayout.Popup((int)m_settings.SortOrder, sortOrderLabels);
-                                        orderIndex = Mathf.Clamp(orderIndex, 0, sortOrderLabels.Length - 1);
-                                        m_settings.SortOrder = (SortOrder)orderIndex;
-                                }
-                        }
+					if(GUILayout.Button("削除", GUILayout.Width(44))) {
+						removeAt = i;
+					}
+				}
 
-                        if(sortKeyIndex == 0) {
-                                m_settings.SortOrder = SortOrder.Ascending; // ソートキー未指定時は初期化
-                        }
+				if(sortKeyIndex == 0) {
+					condition.sortOrder = SortOrder.Ascending; // キー未指定行は昇順に初期化
+				}
+			}
 
-                        GUILayout.Box("", GUILayout.ExpandWidth(true), GUILayout.Height(1));
-                        EditorGUILayout.Space();
-                }
+			if(removeAt >= 0) {
+				sortConditions.RemoveAt(removeAt);
+			}
+
+			using (new EditorGUI.DisabledScope(mappingItems.Length == 0)) {
+				if(GUILayout.Button("ソートキーを追加")) {
+					sortConditions.Add(new SortCondition()); // 第2・第3キー追加用
+				}
+			}
+
+			ApplySortConditionToSettings(sortConditions);
+
+			GUILayout.Box("", GUILayout.ExpandWidth(true), GUILayout.Height(1));
+			EditorGUILayout.Space();
+		}
+
+		/// <summary>編集対象のソート条件配列を構築します。</summary>
+		private List<SortCondition> BuildEditableSortConditions() {
+			if(m_settings.SortConditions != null && m_settings.SortConditions.Length > 0) {
+				return m_settings.SortConditions
+					.Where(condition => condition != null)
+					.Select(condition => new SortCondition {
+						sortKey = condition.sortKey,
+						sortOrder = condition.sortOrder,
+					})
+					.ToList();
+			}
+
+			if(!string.IsNullOrEmpty(m_settings.SortKey)) {
+				return new List<SortCondition> {
+					new() {
+						sortKey = m_settings.SortKey,
+						sortOrder = m_settings.SortOrder,
+					}
+				};
+			}
+
+			return new List<SortCondition>();
+		}
+
+		/// <summary>UI編集結果を設定オブジェクトへ反映します。</summary>
+		private void ApplySortConditionToSettings(List<SortCondition> sortConditions) {
+			var sanitized = (sortConditions ?? new List<SortCondition>())
+				.Where(condition => condition != null)
+				.Select(condition => new SortCondition {
+					sortKey = condition.sortKey,
+					sortOrder = condition.sortOrder,
+				})
+				.ToArray();
+
+			m_settings.SortConditions = sanitized;
+
+			var firstActive = sanitized.FirstOrDefault(condition => !string.IsNullOrEmpty(condition.sortKey)); // 旧項目にも先頭キーを書き戻して互換維持
+
+			m_settings.SortKey = firstActive?.sortKey;
+			m_settings.SortOrder = firstActive?.sortOrder ?? SortOrder.Ascending;
+		}
 
 		public override void DrawMappingRow(MappingFunction func, MappingItem itm) {
 			var selectableNotionFieldsNothing = itm.targetProperties.Length == 0; // 配列向けのマッピング行を描画する際に、Notion側に一致フィールドがあるか確認

--- a/Assets/Scripts/NotionImporter/Editor/ImportDefinitions/ScriptableObjectImportDefinition.cs
+++ b/Assets/Scripts/NotionImporter/Editor/ImportDefinitions/ScriptableObjectImportDefinition.cs
@@ -3,17 +3,27 @@ using NotionImporter.Functions.SubFunction.ScriptableObjects;
 
 namespace NotionImporter {
 
-        /// <summary>ScriptableObject出力時のソート方向を表します。</summary>
-        public enum SortOrder {
+	/// <summary>ScriptableObject出力時のソート方向を表します。</summary>
+	public enum SortOrder {
 
-                Ascending,  // 昇順で並べ替える
-                Descending, // 降順で並べ替える
+		Ascending,  // 昇順で並べ替える
+		Descending, // 降順で並べ替える
 
-        }
+	}
 
-        /// <summary>ScriptableObject向けのインポート定義を保持します。</summary>
-        [Serializable]
-        public class ScriptableObjectImportDefinition : ImportDefinitionBase {
+	/// <summary>配列/リスト出力時の単一ソート条件です。</summary>
+	[Serializable]
+	public class SortCondition {
+
+		public string sortKey; // ソート対象のフィールド名
+
+		public SortOrder sortOrder = SortOrder.Ascending; // ソート順
+
+	}
+
+	/// <summary>ScriptableObject向けのインポート定義を保持します。</summary>
+	[Serializable]
+	public class ScriptableObjectImportDefinition : ImportDefinitionBase {
 
 		/// <summary>ScriptableObject用の定義タイプを返します。</summary>
 		public override string definitionType
@@ -27,16 +37,18 @@ namespace NotionImporter {
 
 		public MappingMode mappingMode; // マッピングモード（配列などの種別）
 
-                public TypeItem targetFieldType; // 配列モード時のターゲット型
+		public TypeItem targetFieldType; // 配列モード時のターゲット型
 
-                public string targetFieldName; // 配列モード時のターゲットフィールド名
+		public string targetFieldName; // 配列モード時のターゲットフィールド名
 
-                public MappingData[] mappingData; // マッピング定義の一覧
+		public MappingData[] mappingData; // マッピング定義の一覧
 
-                public string sortKey; // 出力前に並べ替えるフィールド名
+		public string sortKey; // 互換性維持用の旧ソートキー
 
-                public SortOrder sortOrder = SortOrder.Ascending; // 並べ替えに使用する方向
+		public SortOrder sortOrder = SortOrder.Ascending; // 互換性維持用の旧ソート順
 
-        }
+		public SortCondition[] sortConditions; // 複数ソート条件（新仕様）
+
+	}
 
 }

--- a/Assets/Scripts/NotionImporter/Editor/NotionImporterSettings.cs
+++ b/Assets/Scripts/NotionImporter/Editor/NotionImporterSettings.cs
@@ -80,17 +80,20 @@ namespace NotionImporter {
 		/// <summary>取り込み時のキーとするカラム名を保持します。</summary>
 		public string KeyId { get; set; } // 取り込みキー列名
 
-                /// <summary>キーフィルタリングの使用有無を示します。</summary>
-                public bool UseKeyFiltering { get; set; } = false;
+		/// <summary>キーフィルタリングの使用有無を示します。</summary>
+		public bool UseKeyFiltering { get; set; } = false;
 
-                /// <summary>コレクション出力時に使用するソートキーです。</summary>
-                public string SortKey { get; set; } // 現在選択されているソート対象フィールド
+		/// <summary>コレクション出力時に使用するソートキーです。</summary>
+		public string SortKey { get; set; } // 現在選択されている先頭ソート対象フィールド
 
-                /// <summary>コレクション出力時のソート順設定です。</summary>
-                public SortOrder SortOrder { get; set; } = SortOrder.Ascending; // ソート順（未設定時は昇順）
+		/// <summary>コレクション出力時のソート順設定です。</summary>
+		public SortOrder SortOrder { get; set; } = SortOrder.Ascending; // 先頭ソートの順序（未設定時は昇順）
 
-                /// <summary>Notionから最新のデータベース情報を取得します。</summary>
-                public void RefreshDatabaseInfo() {
+		/// <summary>コレクション出力時の複数ソート条件です。</summary>
+		public SortCondition[] SortConditions { get; set; } = Array.Empty<SortCondition>(); // 第2・第3キーを含む設定
+
+		/// <summary>Notionから最新のデータベース情報を取得します。</summary>
+		public void RefreshDatabaseInfo() {
 			try {
 				var searchQuery = JsonUtility.ToJson(new SearchQuery()); // Notion APIを呼び出して内部状態を更新
 

--- a/Assets/Scripts/NotionImporter/package.json
+++ b/Assets/Scripts/NotionImporter/package.json
@@ -2,7 +2,7 @@
     "name": "com.anest.notionimporter",
     "displayName": "Notion Importer",
     "author": { "name": "Mikan Yukkuri", "url": "https://github.com/YukkuriMikan" },
-    "version": "1.0.8",
+    "version": "1.0.9",
     "unity": "2021.3",
     "description": "Import Notion data into Unity.",
     "dependencies": {


### PR DESCRIPTION
### Motivation
- 配列/リスト出力で現在1件のみ指定可能なソートキーを、ユーザが第2・第3キーを追加・削除できるようにして柔軟な並び替えを可能にするため。 
- 定義ファイルの互換性を保ちつつ新仕様で複数キーを永続化できるようにするため。 

### Description
- UI: `ArrayMapping` のソート設定を単一選択から複数行編集に変更し、`ソートキーを追加` ボタンと各行の `削除` ボタンを追加して第2・第3キーを編集可能にしました（ファイル: `Assets/Scripts/NotionImporter/Editor/Functions/SubFunctions/ScriptableObjects/MappingFunctions/ArrayMapping.cs`）。
- モデル/保存形式: 単一キーの互換用フィールド `sortKey`/`sortOrder` を残しつつ、新しく `SortCondition` クラスと `sortConditions` 配列を導入して複数条件を格納できるようにしました（ファイル: `Assets/Scripts/NotionImporter/Editor/ImportDefinitions/ScriptableObjectImportDefinition.cs`、`Assets/Scripts/NotionImporter/Editor/NotionImporterSettings.cs`）。
- 定義の入出力: 定義ファイルの作成/読み込み処理を拡張して `sortConditions` を保存・復元し、旧フォーマット（`sortKey`/`sortOrder`）からのフォールバックにも対応するようにしました（ファイル: `Assets/Scripts/NotionImporter/Editor/Functions/SubFunctions/CreateScriptableObjectDefinition.cs`）。
- 出力処理: `OutputScriptableObject` のソート処理を複数キーでの優先比較（第1キー→第2キー→...）に対応させ、無効なキーは無視して旧フォーマットからのフォールバックも行うようにしました（ファイル: `Assets/Scripts/NotionImporter/Editor/Functions/OutputFunctions/OutputScriptableObject.cs`）。
- パッケージ: `package.json` のバージョンを `1.0.8` から `1.0.9` にインクリメントしました（ファイル: `Assets/Scripts/NotionImporter/package.json`）。

### Testing
- 実行した自動確認は `git diff --check` で差分の体裁を確認し成功しました。 
- ワークツリー状況を確認するために `git status --short` を実行し、変更が適切に反映されていることを確認しました。 
- Unity Editor 上での動作確認はこの環境では未実施のため、実プロジェクトでのビルド/Editor 動作確認を推奨します。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba423f63648323a2deb51a0c36749b)